### PR TITLE
Potential fix for code scanning alert no. 88: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -1,5 +1,8 @@
 # A recurring workflow which updates the passing/failing/skipped integration tests for Turbopack.
 name: Update Turbopack test manifest
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/next.js/security/code-scanning/88](https://github.com/AKA-NETWORK/next.js/security/code-scanning/88)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: read` is needed for the `actions/checkout` step to read the repository contents.
- `pull-requests: write` is required for the step that creates pull requests.

This change ensures that the `GITHUB_TOKEN` is scoped to the least privileges necessary, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
