### PR TITLE
Potential fix for code scanning alert no. 87: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   test-dev:
     name: Next.js integration tests


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/next.js/security/code-scanning/87](https://github.com/AKA-NETWORK/next.js/security/code-scanning/87)

To fix the issue, add a `permissions` block to the workflow. Since the workflow appears to be running integration tests, it likely only requires read access to the repository contents. The `permissions` block should be added at the root level to apply to all jobs in the workflow. If specific jobs require additional permissions, they can override the root-level permissions.

The minimal permissions required for this workflow are:
- `contents: read` (to read the repository contents).

This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
