### PR TITLE
Potential fix for code scanning alert no. 210: Type confusion through parameter tampering

### DIFF
--- a/examples/cms-agilitycms/lib/preview.ts
+++ b/examples/cms-agilitycms/lib/preview.ts
@@ -87,6 +87,14 @@ export async function validatePreview({ agilityPreviewKey, slug, contentID }) {
     };
   }
 
+  // Ensure agilityPreviewKey is a string
+  if (typeof agilityPreviewKey !== 'string') {
+    return {
+      error: true,
+      message: `Invalid agilitypreviewkey type.`,
+    };
+  }
+
   //sanitize incoming key (replace spaces with '+')
   if (agilityPreviewKey.includes(` `)) {
     agilityPreviewKey = agilityPreviewKey.split(` `).join(`+`);


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/next.js/security/code-scanning/210](https://github.com/AKA-NETWORK/next.js/security/code-scanning/210)

To fix the issue, we need to validate the type of `agilityPreviewKey` before performing string operations. Specifically, we should check if `agilityPreviewKey` is a string. If it is not, we should handle the case appropriately, such as returning an error response. This ensures that type confusion attacks are mitigated.

The changes will be made in the `validatePreview` function in `examples/cms-agilitycms/lib/preview.ts`. We will add a type check for `agilityPreviewKey` and return an error if it is not a string. This fix does not require changes to other files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
